### PR TITLE
Temporarily pin emsdk to 6.0.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
   minizinc:
     name: Build wasm version of MiniZinc
     runs-on: ubuntu-latest
-    container: emscripten/emsdk
+    container: emscripten/emsdk:6.0.1
     outputs:
       cache-key: ${{ steps.get-cache-key.outputs.key }}
       cache-hit: ${{ steps.cache.outputs.cache-hit }}


### PR DESCRIPTION
Needed until emscripten-core/emscripten#27260 lands in a release